### PR TITLE
Update Spring 2.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,37 +1,29 @@
 plugins {
-    id 'org.springframework.boot' version '2.5.0'
-    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
+    id 'org.springframework.boot' version '2.7.11'
+    id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 }
 
 group = 'com.galvanize'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
-repositories {
-    mavenCentral()
-    maven { url 'https://repo.spring.io/snapshot' }
-    maven { url 'https://repo.spring.io/milestone' }
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
-ext {
-    set('springCloudVersion', "2020.0.3-SNAPSHOT")
+repositories {
+    mavenCentral()
 }
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-fabric8-all'
+ 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+ 	implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-fabric8-all:2.1.3'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-}
-
-dependencyManagement {
-    imports {
-        //Needed this change to make IntelliJ work.  Worked fine in plain gradle build
-//        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2020.0.3"
-    }
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,8 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
- 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
- 	implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-fabric8-all:2.1.3'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-fabric8-all:2.1.3'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }


### PR DESCRIPTION
Given Spring decided to deploy their dependencies to maven central this project can be updated to use them more directly.